### PR TITLE
specify the compatible versions of ptflops

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ imageio-ffmpeg
 configargparse
 pillow
 pyrtools
-ptflops
+ptflops<=0.6.7
 tqdm


### PR DESCRIPTION
As the `add_flops_counting_methods()` has been removed from `flops_counter` after version 0.6.7. The compatible versions of ptflops should be specified.

And the requirements.txt has been tested to be correct.